### PR TITLE
[launcher] Proceed init node config on not found err

### DIFF
--- a/launcher/launcher.go
+++ b/launcher/launcher.go
@@ -36,6 +36,7 @@ import (
 	"github.com/aosedge/aos_communicationmanager/imagemanager"
 	"github.com/aosedge/aos_communicationmanager/networkmanager"
 	"github.com/aosedge/aos_communicationmanager/storagestate"
+	"github.com/aosedge/aos_communicationmanager/unitconfig"
 	"github.com/aosedge/aos_communicationmanager/unitstatushandler"
 )
 
@@ -396,7 +397,7 @@ func (launcher *Launcher) initNodeStatus(nodeID string) (*nodeStatus, error) {
 
 func (launcher *Launcher) initNodeConfig(nodeStatus *nodeStatus) error {
 	nodeUnitConfig, err := launcher.resourceManager.GetNodeConfig(nodeStatus.nodeInfo.NodeID, nodeStatus.nodeInfo.NodeType)
-	if err != nil {
+	if err != nil && !errors.Is(err, unitconfig.ErrNotFound) {
 		return aoserrors.Wrap(err)
 	}
 

--- a/unitconfig/unitconfig.go
+++ b/unitconfig/unitconfig.go
@@ -31,6 +31,13 @@ import (
 	"github.com/aosedge/aos_communicationmanager/config"
 )
 
+/**********************************************************************************************************************
+* Consts
+**********************************************************************************************************************/
+
+// ErrNotFound error to detect that item not found.
+var ErrNotFound = errors.New("not found")
+
 /***********************************************************************************************************************
  * Types
  **********************************************************************************************************************/
@@ -164,7 +171,7 @@ func (instance *Instance) GetNodeConfig(nodeID, nodeType string) (cloudprotocol.
 		}
 	}
 
-	return cloudprotocol.NodeConfig{}, aoserrors.New("not found")
+	return cloudprotocol.NodeConfig{}, ErrNotFound
 }
 
 // GetNodeConfig returns node config of the node with given id and type.


### PR DESCRIPTION
Develop branch implementation proceeds with init node config if it's not found.
Current feature branch impl leads to next errors:

Jul 19 15:58:15 main aos_communicati[850]: time="2024-07-19 15:58:15.713" level=warning msg="Can't update node config due to: open /var/aos/
workdirs/cm/aos_unit.cfg: no such file or directory [github.com/aosedge/aos_communicationmanager/unitconfig.(*Instance).load:238]" NodeID=a0
f9bb44a24f4397a3b15100e70d9d9b
Jul 19 15:58:15 main aos_communicati[850]: time="2024-07-19 15:58:15.713" level=debug msg="Init node status" nodeID=a0f9bb44a24f4397a3b15100
e70d9d9b
Jul 19 15:58:15 main aos_communicati[850]: time="2024-07-19 15:58:15.713" level=debug msg="Get node info" nodeID=a0f9bb44a24f4397a3b15100e70
d9d9b
Jul 19 15:58:15 main aos_communicati[850]: time="2024-07-19 15:58:15.713" level=error msg="Can't init node: not found [github.com/aosedge/ao
s_communicationmanager/unitconfig.(*Instance).GetNodeConfig:167]"