### PR TITLE
[launcher] Fix sending run instances for paused nodes

### DIFF
--- a/launcher/launcher.go
+++ b/launcher/launcher.go
@@ -260,7 +260,7 @@ func (launcher *Launcher) initNodes(rebalancing bool) error {
 			continue
 		}
 
-		if nodeInfo.Status != cloudprotocol.NodeStatusProvisioned {
+		if nodeInfo.Status == cloudprotocol.NodeStatusUnprovisioned {
 			log.WithField("nodeID", nodeID).Debug("Skip not provisioned node")
 
 			continue

--- a/launcher/nodehandler.go
+++ b/launcher/nodehandler.go
@@ -360,7 +360,12 @@ func (node *nodeHandler) getRequestedRAM(
 func getNodesByStaticResources(nodes []*nodeHandler,
 	serviceConfig aostypes.ServiceConfig, instanceInfo cloudprotocol.InstanceInfo,
 ) ([]*nodeHandler, error) {
-	resultNodes := getNodeByRunners(nodes, serviceConfig.Runners)
+	resultNodes := getActiveNodes(nodes)
+	if len(resultNodes) == 0 {
+		return resultNodes, aoserrors.Errorf("no active nodes")
+	}
+
+	resultNodes = getNodeByRunners(nodes, serviceConfig.Runners)
 	if len(resultNodes) == 0 {
 		return resultNodes, aoserrors.Errorf("no nodes with runner: %s", serviceConfig.Runners)
 	}
@@ -376,6 +381,18 @@ func getNodesByStaticResources(nodes []*nodeHandler,
 	}
 
 	return resultNodes, nil
+}
+
+func getActiveNodes(nodes []*nodeHandler) []*nodeHandler {
+	resultNodes := make([]*nodeHandler, 0)
+
+	for _, node := range nodes {
+		if node.nodeInfo.Status == cloudprotocol.NodeStatusProvisioned {
+			resultNodes = append(resultNodes, node)
+		}
+	}
+
+	return resultNodes
 }
 
 func getNodesByDevices(nodes []*nodeHandler, desiredDevices []aostypes.ServiceDevice) []*nodeHandler {


### PR DESCRIPTION
We don't initialize paused nodes as result run instances command is not sent for such nodes. The fix is to initialize all nodes except unprovisioned  and selects only provisioned for balancing. In this case run instances command with no instances will be sent to paused, error etc. nodes.