### PR TITLE
[umcontroller] Dont stop grpc connection in stopChannel as it leads to deadlock

### DIFF
--- a/umcontroller/umcontroller.go
+++ b/umcontroller/umcontroller.go
@@ -313,6 +313,12 @@ func (umCtrl *Controller) Close() {
 
 	close(umCtrl.newComponentsChannel)
 	umCtrl.operable = false
+
+	log.Debug("Close all connections")
+
+	umCtrl.closeUMServer()
+	umCtrl.updateFinishCond.Broadcast()
+
 	umCtrl.stopChannel <- true
 }
 
@@ -480,12 +486,6 @@ func (umCtrl *Controller) processInternalMessages() {
 			umCtrl.handleCertChange()
 
 		case <-umCtrl.stopChannel:
-			log.Debug("Close all connections")
-
-			umCtrl.closeUMServer()
-
-			umCtrl.updateFinishCond.Broadcast()
-
 			return
 		}
 	}


### PR DESCRIPTION
stopChannel calls grpc.GracefulStop that waits for RegisterUM to finish, that waits for umCtrl.eventChannel to be read in the same thread as stopChannel