### PR TITLE
[networkmanager] Automatically detect networkID in remove instance

### DIFF
--- a/launcher/launcher.go
+++ b/launcher/launcher.go
@@ -81,7 +81,7 @@ type NetworkManager interface {
 	PrepareInstanceNetworkParameters(
 		instanceIdent aostypes.InstanceIdent, networkID string,
 		params networkmanager.NetworkParameters) (aostypes.NetworkParameters, error)
-	RemoveInstanceNetworkParameters(instanceIdent aostypes.InstanceIdent, networkID string)
+	RemoveInstanceNetworkParameters(instanceIdent aostypes.InstanceIdent)
 	RestartDNSServer() error
 	GetInstances() []aostypes.InstanceIdent
 	UpdateProviderNetwork(providers []string, nodeID string) error
@@ -640,13 +640,7 @@ nextNetInstance:
 			}
 		}
 
-		serviceInfo, err := launcher.imageProvider.GetServiceInfo(netInstance.ServiceID)
-		if err != nil {
-			log.WithField("serviceID", netInstance.ServiceID).Errorf("Can't get service info: %v", err)
-			continue
-		}
-
-		launcher.networkManager.RemoveInstanceNetworkParameters(netInstance, serviceInfo.ProviderID)
+		launcher.networkManager.RemoveInstanceNetworkParameters(netInstance)
 	}
 }
 

--- a/launcher/launcher_test.go
+++ b/launcher/launcher_test.go
@@ -1094,10 +1094,14 @@ func (network *testNetworkManager) PrepareInstanceNetworkParameters(
 	}, nil
 }
 
-func (network *testNetworkManager) RemoveInstanceNetworkParameters(
-	instanceIdent aostypes.InstanceIdent, networkID string,
-) {
-	delete(network.networkInfo[networkID], instanceIdent)
+func (network *testNetworkManager) RemoveInstanceNetworkParameters(instanceIdent aostypes.InstanceIdent) {
+	for _, network := range network.networkInfo {
+		if _, ok := network[instanceIdent]; ok {
+			delete(network, instanceIdent)
+
+			break
+		}
+	}
 }
 
 func (network *testNetworkManager) GetInstances() (instances []aostypes.InstanceIdent) {

--- a/networkmanager/networkmanager_test.go
+++ b/networkmanager/networkmanager_test.go
@@ -158,7 +158,7 @@ func TestBaseNetwork(t *testing.T) {
 
 	for _, data := range testData {
 		if data.removeConfig {
-			manager.RemoveInstanceNetworkParameters(data.instance, "network1")
+			manager.RemoveInstanceNetworkParameters(data.instance)
 
 			continue
 		}


### PR DESCRIPTION
We can't reliable take networkID during removing instances in launcher as at that time the service can be already removed. Network manager has capability to detect networkID itself. Use this approach to fix removing instances for deleted services.