### PR TITLE
[umcontroller] Decrease log level for "UM in shutdown state error"

### DIFF
--- a/umcontroller/umcontroller.go
+++ b/umcontroller/umcontroller.go
@@ -803,7 +803,7 @@ func (umCtrl *Controller) cleanupUpdateData() {
 
 func (umCtrl *Controller) generateFSMEvent(event string, args ...interface{}) {
 	if !umCtrl.operable {
-		log.Error("Update controller in shutdown state")
+		log.Debug("Update controller in shutdown state")
 		return
 	}
 


### PR DESCRIPTION
Error occurs on cm service shutdown, when "um disconnected" event comes after UMController::Close called. Because this error msg doesn't indicate any problem, and UM controller will be removed in the future, it was decided to suppress the error, by decreasing log level.