### PR TITLE
[unitstatushandler] Fix calculating FOTA/SOTA update interval

### DIFF
--- a/unitstatushandler/unitstatushandler_internal_test.go
+++ b/unitstatushandler/unitstatushandler_internal_test.go
@@ -1464,7 +1464,7 @@ func TestTimeTable(t *testing.T) {
 					DayOfWeek: 1, TimeSlots: []cloudprotocol.TimeSlot{
 						{
 							Start: aostypes.Time{Time: time.Date(0, 1, 1, 0, 0, 0, 0, time.Local)},
-							End:   aostypes.Time{Time: time.Date(0, 1, 1, 0, 0, 0, 0, time.Local)},
+							End:   aostypes.Time{Time: time.Date(0, 1, 1, 0, 0, 0, 1, time.Local)},
 						},
 					},
 				},
@@ -1562,6 +1562,20 @@ func TestTimeTable(t *testing.T) {
 				},
 			},
 			result: 70 * time.Hour,
+		},
+		{
+			fromDate: time.Date(1977, 4, 6, 6, 0, 0, 0, time.Local),
+			timetable: []cloudprotocol.TimetableEntry{
+				{
+					DayOfWeek: uint(time.Wednesday), TimeSlots: []cloudprotocol.TimeSlot{
+						{
+							Start: aostypes.Time{Time: time.Date(0, 1, 1, 0, 0, 0, 0, time.Local)},
+							End:   aostypes.Time{Time: time.Date(0, 1, 1, 1, 0, 0, 0, time.Local)},
+						},
+					},
+				},
+			},
+			result: (24*7 - 6) * time.Hour,
 		},
 	}
 

--- a/unitstatushandler/updatestatemachine.go
+++ b/unitstatushandler/updatestatemachine.go
@@ -160,7 +160,10 @@ func (stateMachine *updateStateMachine) sendEvent(event string, managerErr error
 }
 
 func (stateMachine *updateStateMachine) scheduleUpdate(schedule cloudprotocol.ScheduleRule) {
-	var updateTime time.Duration
+	var (
+		updateTime time.Duration
+		err        error
+	)
 
 	switch schedule.Type {
 	case cloudprotocol.TriggerUpdate:
@@ -168,7 +171,10 @@ func (stateMachine *updateStateMachine) scheduleUpdate(schedule cloudprotocol.Sc
 		return
 
 	case cloudprotocol.TimetableUpdate:
-		updateTime, _ = getAvailableTimetableTime(time.Now(), schedule.Timetable)
+		if updateTime, err = getAvailableTimetableTime(time.Now(), schedule.Timetable); err != nil {
+			log.WithField("err", err).Error("Can't get available timetable time")
+			return
+		}
 
 		log.WithFields(log.Fields{"in": updateTime}).Debug("Schedule timetable update")
 


### PR DESCRIPTION
In current implementation, getAvailableTimetableTime function returns wrong duration value if time slot is defined in same day but befor fromDate time. Reimplement this function in the following way:

- create map of time slots per day of week;
- loop through this map starting from current day of week and calculate update interval based on nearest available time slot;
- do not include end time into the interval: [start, end);
- update unit test accordingly.