### PR TITLE
[downloader] Fix download progress log entry

### DIFF
--- a/downloader/downloader.go
+++ b/downloader/downloader.go
@@ -603,7 +603,7 @@ func (downloader *Downloader) download(url string, result *downloadResult) (err 
 		case <-timer.C:
 			downloader.sender.SendAlert(downloader.prepareDownloadAlert(resp, result, "Download status"))
 
-			log.WithFields(log.Fields{"complete": resp.BytesComplete(), "total": resp.Size}).Debug("Download progress")
+			log.WithFields(log.Fields{"complete": resp.BytesComplete(), "total": resp.Size()}).Debug("Download progress")
 
 		case <-resp.Done:
 			if err = resp.Err(); err != nil {


### PR DESCRIPTION
Logrus can not add field to the log if field value is a function or a pointer to a function.
This patch fixes the issue by passing the function call result to the log entry.