### PR TITLE
[launcher] Fix shared count zero value

### DIFF
--- a/launcher/nodehandler.go
+++ b/launcher/nodehandler.go
@@ -188,7 +188,11 @@ func (node *nodeHandler) resetDeviceAllocations() {
 	node.deviceAllocations = make(map[string]int)
 
 	for _, device := range node.nodeConfig.Devices {
-		node.deviceAllocations[device.Name] = device.SharedCount
+		if device.SharedCount > 0 {
+			node.deviceAllocations[device.Name] = device.SharedCount
+		} else {
+			node.deviceAllocations[device.Name] = math.MaxInt
+		}
 	}
 }
 


### PR DESCRIPTION
According to spec, zero value means no share limits. But it is treated as no shares at all. Set device allocations number to MaxInt if shared count is zero.